### PR TITLE
Update jinja compiler to use the JSON files

### DIFF
--- a/WebPage/src/template/committee.html
+++ b/WebPage/src/template/committee.html
@@ -160,17 +160,17 @@
               <tr>
                 <td><span class="style1">{{ meeting['meeting_date'] }}</span></td>
 
-                {% if 'http' in meeting['video'] %}
+                {% if meeting['video'] %}
                 <td>
                   <a href="{{ meeting['video'] }}" target="_top" data-toggle="tooltip">
                     Click for Video Minutes and Agenda
                   </a>
-                {% elif 'http' in meeting['minutes'] %}
+                {% elif meeting['minutes'] %}
                 <td>
                   <a href="{{ meeting['minutes'] }}" target="_top" data-toggle="tooltip">
                     Click for Minutes
                   </a>
-                {% elif 'http' in meeting['agenda'] %}
+                {% elif meeting['agenda'] %}
                 <td>
                   Meeting at {{ meeting['meeting_time'] }} in {{ meeting['meeting_location'] }} |
                   <a href="{{ meeting['agenda'] }}" target="_top">Click for agenda</a>
@@ -179,7 +179,7 @@
                     Meeting at {{ meeting['meeting_time'] }} in {{ meeting['meeting_location'] }}
                 {% endif %}
 
-                {% if 'http' in meeting['eComment'] %}
+                {% if meeting['eComment'] %}
                 | <a href="{{ meeting['eComment'] }}" target="_top">Click to comment electronically</a>
                 {% endif %}
 


### PR DESCRIPTION
This pull request updates the jinja complier logic (in `main.py`) to use the
JSON files created by the non-event-scraper.

Conveniently, these JSON files are semantically equal to the previous CSV
files (thanks, Phil!), so converting the jinja-based website generator to use them only
required a replacement of the CSV loading with JSON loading.

I also restructured the generation code to be a bit more sequential
according to this process:
1. Determine a list of years to render
2. Load data from those years
3. Generate the sidebar based off the most recent data
4. For each year to render, render the page