### PR TITLE
Fix up makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,6 @@ __pycache__
 /WebPage/website/pc/*
 /WebPage/website/mobile/*
 !/WebPage/website/css/style.css
-WebPage/website/scraped/year2014.csv
-WebPage/website/scraped/year2015.csv
-WebPage/website/scraped/year2016.csv
-WebPage/website/scraped/year2017.csv
-WebPage/website/scraped/year2018.csv
-WebPage/website/scraped/year2019.csv
+WebPage/website/scraped/*
 /IOS/
 /scraper/.ipynb_checkpoints/*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-WebPage/website/scraped/year%.csv: run_calendar.py
-	python run_calendar.py -d $(subst .csv,,$(subst WebPage/website/scraped/year,,$@)) > $@
+WebPage/website/scraped/year%.csv: run_calendar2.py
+	python run_calendar2.py -d $(subst .csv,,$(subst WebPage/website/scraped/year,,$@)) > $@
 
 .PHONY: clean
 


### PR DESCRIPTION
I ran into issues with the README instructions to run `make scrape generate`. I found that the `run_calendar.py` script seems like it's using an outdated script. With this update I was able to run `make scrape generate` locally