### PR TITLE
Add meeting agenda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-WebPage/website/scraped/year%.json: run_calendar.py
-	python run_meeting_json.py --year $(subst .json,,$(subst WebPage/website/scraped/year,,$@)) --output $@
+WebPage/website/scraped/Scraper%.json: run_calendar.py
+	python run_meeting_json.py --year $(subst .json,,$(subst WebPage/website/scraped/Scraper,,$@)) --output $@
 
 .PHONY: clean
 
 serve:
 	cd WebPage/website && python -m http.server
 
-scrape: WebPage/website/scraped/year2019.json WebPage/website/scraped/year2018.json WebPage/website/scraped/year2017.json WebPage/website/scraped/year2016.json WebPage/website/scraped/year2015.json WebPage/website/scraped/year2014.json
+scrape: WebPage/website/scraped/Scraper2019.json WebPage/website/scraped/Scraper2018.json WebPage/website/scraped/Scraper2017.json WebPage/website/scraped/Scraper2016.json WebPage/website/scraped/Scraper2015.json WebPage/website/scraped/Scraper2014.json
 
 generate: WebPage/src/main.py
 	python WebPage/src/main.py

--- a/Scraper_full_json.sh
+++ b/Scraper_full_json.sh
@@ -43,7 +43,7 @@ for ((YEAR=2014; YEAR<=CURRENTYEAR; YEAR++)); do      # Start the loop from 2014
         if [ $retVal -ne 0 ]; then
             echo "Scraper error. Will ignore"
         else
-            mv  WebPage/website/scraped/ScraperTEMP.json  WebPage/website/scraped/year$YEAR.json
+            mv  WebPage/website/scraped/ScraperTEMP.json  WebPage/website/scraped/Scraper$YEAR.json
             echo "Successful scraper file for year $YEAR"
         fi
         echo ""

--- a/WebPage/src/main.py
+++ b/WebPage/src/main.py
@@ -56,6 +56,13 @@ def load_meetings(scraped_data, committee_name_filter=None, upcoming_only=False,
             if daydiff < 0:
                 continue
 
+        # Make agenda items more presentable
+        for agendaItem in meeting['EventAgenda']:
+            title = agendaItem.get('EventItemTitle', '')
+            if title and title.startswith('Subject:'):
+                agendaItem['EventItemSubject'] = title.split("\n")[0].replace("Subject:","")
+                meeting['EventAgendaDisplayable'] = True
+
         # Do not skip upcoming meetings in the Calendar if they are cancelled
         if not upcoming_only:
             # skip the meeting if it's a cancellation

--- a/WebPage/src/template/committee.html
+++ b/WebPage/src/template/committee.html
@@ -100,6 +100,20 @@
           <div class="event-day__item-details">
             <font size="+1">{{ event['EventBodyName'] }}</font> <br/>
             {{ event['EventLocation'] }}
+            {% if event.get('EventAgendaDisplayable') %}
+              <details>
+                <summary class="mb-3">Meeting Agenda</summary>
+                <ul>
+                  {% for agendaItem in event['EventAgenda'] %}
+                    {% if 'EventItemSubject' in agendaItem %}
+                      <li>
+                        <b>{{ agendaItem['EventItemMatterType'] }}</b> - {{ agendaItem['EventItemSubject'] }}
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              </details>
+            {% endif %}
           </div>
         </div>
         {% endfor %}


### PR DESCRIPTION
![meeting-agenda](https://user-images.githubusercontent.com/16271389/60567137-e0a47f00-9d1d-11e9-99d3-37b26e5cda8d.gif)

Also another change is to clean up the `year.json` vs `Scraper.json` discrepency from these two commits:

https://github.com/openoakland/councilmatic/commit/c7414f3e7989546f1eed8af1f57eb1d47a0e2c02
https://github.com/openoakland/councilmatic/commit/f82ab4c51f1aa805f1936728134c9d15661ec154

doesn't really matter what it's called but it just has to be consistent so that setup scripts work out the gate for newbies