### PR TITLE
Added a temp fix near line 75 of src-Scraper/run_meeting_json.py.

### DIFF
--- a/src-Scraper/run_meeting_json.py
+++ b/src-Scraper/run_meeting_json.py
@@ -13,6 +13,8 @@ import json
 import datetime as dt
 import argparse
 import logging
+import os.path #Temp fix near line 75
+from os import path #Part of same temp fix
 
 import re
 
@@ -70,9 +72,12 @@ def scrape_api(days, year, meeting_file, calendar_dir):
                             meeting['EventVideoPath'] = zoomLink[0]
 
                 filename = str(calendar_dir) + str(meeting['EventId']) + ".ics"
-                f = open(filename, 'w')
-                f.write("BEGIN:VCALENDAR\nVERSION:2.0\nCALSCALE:GREGORIAN\nBEGIN:VEVENT\nDTSTART;TZID=America/Los_Angeles:" + meeting_date.strftime("%Y%m%d") + "T" + str(dt.datetime.strptime(str(meeting['EventTime']), "%I:%M %p").strftime("%H%M%S")) + "\nDTEND;TZID=America/Los_Angeles:" + meeting_date.strftime("%Y%m%d") + "T" + str(int(dt.datetime.strptime(str(meeting['EventTime']), "%I:%M %p").strftime("%H%M%S"))+10000) + "\nSUMMARY:" + str(meeting['EventBodyName']) + "\nURL:" + str(meeting['EventInSiteURL']) + "\nDESCRIPTION:For details link here:" + str(meeting['EventInSiteURL']) + "\nLOCATION:" + str(meeting['EventLocation']) + "\nEND:VEVENT\nEND:VCALENDAR\n")
-                f.close()
+                if path.exists(filename): #Temp work around for error of file not found
+                    f = open(filename, 'w')
+                    f.write("BEGIN:VCALENDAR\nVERSION:2.0\nCALSCALE:GREGORIAN\nBEGIN:VEVENT\nDTSTART;TZID=America/Los_Angeles:" + meeting_date.strftime("%Y%m%d") + "T" + str(dt.datetime.strptime(str(meeting['EventTime']), "%I:%M %p").strftime("%H%M%S")) + "\nDTEND;TZID=America/Los_Angeles:" + meeting_date.strftime("%Y%m%d") + "T" + str(int(dt.datetime.strptime(str(meeting['EventTime']), "%I:%M %p").strftime("%H%M%S"))+10000) + "\nSUMMARY:" + str(meeting['EventBodyName']) + "\nURL:" + str(meeting['EventInSiteURL']) + "\nDESCRIPTION:For details link here:" + str(meeting['EventInSiteURL']) + "\nLOCATION:" + str(meeting['EventLocation']) + "\nEND:VEVENT\nEND:VCALENDAR\n")
+                    f.close()
+                else:
+                    print("The following file was not found near line 78 of run_meeting_json.py:",filename)
                     
         except requests.exceptions.RequestException:
             logging.warning("Error retrieving agenda...")


### PR DESCRIPTION
The fix bypasses a file not found error that occurs only in production (WebPage/website/calendars/8546.ics).  Prints error to console.