### PR TITLE
ScraperUpdate2.sh was modified to comment out code that copied and ti…

### DIFF
--- a/ScraperUpdate2.sh
+++ b/ScraperUpdate2.sh
@@ -84,7 +84,7 @@ prevfilename="WebPage/website/scraped/Scraper-holdprevious.json"
 printf -v currentdwnldfilename "WebPage/website/scraped/Scraper%s.json" "$CURRENTYEAR"
 
 # ##### Rename the last download file to a generic "prev" name. (Scraper-holdprevious.json)
-mv $currentdwnldfilename $prevfilename
+#mv $currentdwnldfilename $prevfilename
 
 # echo $LASTYEAR $CURRENTYEAR $NEXTYEAR $CURRENTMONTH #uncomment for debug 
 
@@ -135,16 +135,20 @@ retVal=$?
 # USE PARAMS for the years in the two file names below.
 
 # Compare files to see if copy should be saved
-if cmp -s "$prevfilename" "$currentdwnldfilename" ; then
-    echo "Nothing changed between last and newly downloaded JSON data file."
-    echo ''
-    rm -f $prevfilename
-else
-    echo "Something changed between last and newly downloaded JSON data file. Labeling and saving the previous file."
-    echo ''
-#   ##### Change the generic "previous" name to a dated file to hold for testing and verification.
-    mv $prevfilename "${prevfilename%.*}_$(date -d@$(stat --printf='%Y' "$prevfilename") +%Y%m%d%H%M%S).${prevfilename##*.}"
-fi
+# This section has been commented out because many "holdprevious" files were being
+# generated with each update.  Need to disable now and debug later if the change
+# detection is to be developed.  Also see the mv command near line 87 which has been
+# commented out.
+#if cmp -s "$prevfilename" "$currentdwnldfilename" ; then
+#    echo "Nothing changed between last and newly downloaded JSON data file."
+#    echo ''
+#    rm -f $prevfilename
+#else
+#    echo "Something changed between last and newly downloaded JSON data file. Labeling and saving the previous file."
+#    echo ''
+##   ##### Change the generic "previous" name to a dated file to hold for testing and verification.
+#    mv $prevfilename "${prevfilename%.*}_$(date -d@$(stat --printf='%Y' "$prevfilename") +%Y%m%d%H%M%S).${prevfilename##*.}"
+#fi
 
 #
 # Check if December

--- a/src-Webpage/template/base.html
+++ b/src-Webpage/template/base.html
@@ -96,12 +96,6 @@
             Sign Up to Speak
             <i class="fas fa-external-link-alt fa-xs"></i>
 	  </a>
-	  
-	<p>
-          <a href="https://forms.gle/vf1gR78Pub1NWcGD9" target="_blank">
-            Participate in Oakland Council Survey
-            <i class="fas fa-external-link-alt fa-xs"></i>
-          </a>
       </details>
 
       	<p style="font-size: 1.5rem; margin-top: 1rem;">


### PR DESCRIPTION
ScraperUpdate2.sh was modified to comment out code that copied and timestamped the previous download if it was found to differ from the current download.  Something was not functioning as originally designed and many multiple copies were being stored with each update cycle.  The change to base.html removes a link to a survey which is no longer relevant (implement by Columbia students).